### PR TITLE
Fix MidiSequence.DivisionType; logic was swapped

### DIFF
--- a/MidiSharp/MidiSequence.cs
+++ b/MidiSharp/MidiSequence.cs
@@ -85,7 +85,7 @@ namespace MidiSharp
         /// <summary>Gets the division type of the sequence.</summary>
         public DivisionType DivisionType
         {
-            get { return (Division & 0x8000) != 0 ? DivisionType.TicksPerBeat : DivisionType.FramesPerSecond; }
+            get { return (Division & 0x8000) != 0 ? DivisionType.FramesPerSecond : DivisionType.TicksPerBeat; }
         }
 
         /// <summary>


### PR DESCRIPTION
MidiSequence.DivisionType would return DivisionType.TicksPerBeat when the MSB (bit 15) was set to 1, whereas the spec denotes that bit as meaning the division is "frames per second". Simple swap mistake, figured I'd let you know.