### PR TITLE
Add calc of absolute event time and note length

### DIFF
--- a/MidiSharp/Events/MidiEvent.cs
+++ b/MidiSharp/Events/MidiEvent.cs
@@ -16,6 +16,14 @@ namespace MidiSharp.Events
 	{
 		/// <summary>The amount of time before this event.</summary>
 		private long m_deltaTime;
+		/// <summary>This auxiliary parameter can be set and updated by calling MidiSequence.CalculateAbsolutePulseAndTime(),
+		/// and reflects the absolute number of pulses/ticks since the beginning of the track.
+		/// Value below 0 means not set. Not set by default.</summary>
+		public long m_absPulse = -1;
+		/// <summary>This auxiliary parameter can be set and updated by calling MidiSequence.CalculateAbsolutePulseAndTime(),
+		/// and reflects the amount of time in seconds since the beginning of the track, accounting for tempo changes.
+		/// Value below 0 means not set. Not set by default.</summary>
+		public float m_absTime = -1;
 
 		/// <summary>Initialize the event.</summary>
 		/// <param name="deltaTime">The amount of time before this event.</param>

--- a/MidiSharp/Events/Voice/Note/OnNoteVoiceMidiEvent.cs
+++ b/MidiSharp/Events/Voice/Note/OnNoteVoiceMidiEvent.cs
@@ -16,6 +16,10 @@ namespace MidiSharp.Events.Voice.Note
         internal const byte CategoryId = 0x9;
         /// <summary>The velocity of the note (0x0 to 0x7F).</summary>
         private byte m_velocity;
+        /// <summary>This auxiliary parameter can be set and updated by calling MidiSequence.CalculateOnNoteVoiceMidiEventLength(),
+        /// and reflects the amount of time in seconds this note is ringing.
+        /// Value below 0 means not set. Not set by default.</summary>
+        public float m_absLength = -1;
 
         /// <summary>Initialize the NoteOn MIDI event message.</summary>
         /// <param name="deltaTime">The amount of time before this event.</param>


### PR DESCRIPTION
This commit adds auxiliary functions to:
- calculate and store absotule event times in MidiEvent objects
- calculate and store absolute note length in OnNoteVoiceMidiEvent objects